### PR TITLE
Update format arguments such that they are suitable for NSInteger/NSUInteger

### DIFF
--- a/WTReTextField/WTReParser.m
+++ b/WTReTextField/WTReParser.m
@@ -159,16 +159,16 @@
         } else if (_countTo == 1) {
             pat = @"?";
         } else {
-            pat = [NSString stringWithFormat:@"{,%u}", _countTo];
+            pat = [NSString stringWithFormat:@"{,%tu}", _countTo];
         }
     } else if (_countFrom == 1 && _countTo == NSUIntegerMax) {
         pat = @"+";
     } else if (_countFrom == _countTo) {
-        pat = [NSString stringWithFormat:@"{%u}", _countFrom];
+        pat = [NSString stringWithFormat:@"{%tu}", _countFrom];
     } else if (_countTo == NSUIntegerMax) {
-        pat = [NSString stringWithFormat:@"{%u,}", _countFrom];
+        pat = [NSString stringWithFormat:@"{%tu,}", _countFrom];
     } else {
-        pat = [NSString stringWithFormat:@"{%u,%u}", _countFrom, _countTo];
+        pat = [NSString stringWithFormat:@"{%tu,%tu}", _countFrom, _countTo];
     }
     
     if (_greedy) return pat;
@@ -508,7 +508,7 @@
 - (void)raiseParserError:(NSString*)error atPos:(NSUInteger)pos
 {
     NSString *pat = [NSString stringWithFormat:@"%@ \u25B6%@", [_pattern substringToIndex:pos], [_pattern substringFromIndex:pos]];
-    @throw [NSException exceptionWithName:@"Parse error" reason:[NSString stringWithFormat:@"%@ @ pos %d: %@", error, pos, pat] userInfo:nil];
+    @throw [NSException exceptionWithName:@"Parse error" reason:[NSString stringWithFormat:@"%@ @ pos %zd: %@", error, pos, pat] userInfo:nil];
 }
 
 - (WTReCharacterBase*)parseCharset:(NSString*)pattern inRange:(NSRange)range enclosed:(BOOL)enclosed


### PR DESCRIPTION
This resolves the following warnings in Xcode 6 and higher:

```
WTReParser.m:162:56: Values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead
WTReParser.m:167:51: Values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead
WTReParser.m:169:52: Values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead
WTReParser.m:171:66: Values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead
WTReParser.m:511:119: Values of type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead
```
